### PR TITLE
Remove `+PlugInstall` covered by `+PlugUpdate`

### DIFF
--- a/apps/vim/update.sh
+++ b/apps/vim/update.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-vim +PlugUpgrade +PlugClean +PlugInstall +PlugUpdate +qall
+vim +PlugUpgrade +PlugClean +PlugUpdate +qall


### PR DESCRIPTION
Even if you haven't installed any plugin, vim-plug will clone them on `PlugUpdate`.
